### PR TITLE
[init] responseAdvice, ExceptionHandler 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,18 +30,27 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.ai:spring-ai-redis-store-spring-boot-starter'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//database
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'org.postgresql:postgresql'
+
+	// redis 설치 후 주석 해제하기
+	// implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// 임시 로컬 DB. 진짜 DB 에 연결 한 다음 아래 h2는 삭제하기
+	runtimeOnly 'com.h2database:h2'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 dependencyManagement {

--- a/src/main/java/ssu/opensource/advice/GlobalExceptionHandler.java
+++ b/src/main/java/ssu/opensource/advice/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package ssu.opensource.advice;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import ssu.opensource.exception.BusinessException;
+import ssu.opensource.exception.ForbiddenException;
+import ssu.opensource.exception.NotFoundException;
+import ssu.opensource.exception.code.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 요청은 정상이나 비즈니스 중 실패가 있는 경우
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<BusinessErrorCode> handleBusinessException(BusinessException e) {
+        log.error("GlobalExceptionHandler catch BusinessException : {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+
+    // DB에서 데이터를 찾지 못한 경우
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<NotFoundErrorCode> handleNotFoundException(NotFoundException e){
+        log.error("GlobalExceptionHandler catch NotFoundException : {}", e.getErrorCode().getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+
+    // 존재하지 않는 요청에 대한 예외
+    @ExceptionHandler(value={NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
+    public ResponseEntity<NotFoundErrorCode> handleNoPageFoundException(Exception e) {
+        log.error("GlobalExceptionHandler catch NoHandlerFoundException : {}", e.getMessage());
+        return ResponseEntity
+                .status(NotFoundErrorCode.NOT_FOUND_END_POINT.getHttpStatus())
+                .body(NotFoundErrorCode.NOT_FOUND_END_POINT);
+    }
+
+    // 기본 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<InternalServerErrorCode> handleException(Exception e) {
+        log.error("handleException() in GlobalExceptionHandler throw Exception : {}", e.getMessage());
+        return ResponseEntity
+                .status(InternalServerErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(InternalServerErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    // 유효하지 않은 인자가 들어온 경우 (@Valid 사용 시 수행)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<IllegalArgumentErrorCode> handleException(MethodArgumentNotValidException e) {
+        log.error("handleException() in GlobalExceptionHandler throw MethodArgumentNotValidException : {}", e.getMessage());
+        return ResponseEntity
+                .status(IllegalArgumentErrorCode.INVALID_ARGUMENTS.getHttpStatus())
+                .body(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
+    }
+
+    //권한이 없는 경우
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ForbiddenErrorCode> handleException(ForbiddenException e) {
+        log.error("handleException() in GlobalExceptionHandler throw ForbiddenException : {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+}
+

--- a/src/main/java/ssu/opensource/advice/ResponseDtoAdvice.java
+++ b/src/main/java/ssu/opensource/advice/ResponseDtoAdvice.java
@@ -1,0 +1,36 @@
+package ssu.opensource.advice;
+
+import lombok.NonNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import ssu.opensource.dto.common.ResponseDto;
+import ssu.opensource.exception.code.DefaultErrorCode;
+
+@RestControllerAdvice
+public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {
+    @Override
+    public boolean supports(MethodParameter returnType, @NonNull Class converterType) {
+        return !(returnType.getParameterType() == ResponseDto.class)
+                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            @NonNull MethodParameter returnType,
+            @NonNull MediaType selectedContentType,
+            @NonNull Class selectedConverterType,
+            @NonNull ServerHttpRequest request,
+            @NonNull ServerHttpResponse response
+    ) {
+        if (body instanceof DefaultErrorCode)
+            return ResponseDto.fail((DefaultErrorCode) body);
+        return ResponseDto.success(body);
+    }
+}
+

--- a/src/main/java/ssu/opensource/dto/common/ResponseDto.java
+++ b/src/main/java/ssu/opensource/dto/common/ResponseDto.java
@@ -1,0 +1,17 @@
+package ssu.opensource.dto.common;
+
+import ssu.opensource.exception.code.DefaultErrorCode;
+
+public record ResponseDto<T> (
+        String code,
+        T data,
+        String message
+) {
+    public static <T> ResponseDto<T> success(final T data) {
+        return new ResponseDto<>("success", data, null);
+    }
+
+    public static <T> ResponseDto<T> fail(DefaultErrorCode code) {
+        return new ResponseDto<>(code.getCode(), null, code.getMessage());
+    }
+}

--- a/src/main/java/ssu/opensource/exception/BusinessException.java
+++ b/src/main/java/ssu/opensource/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package ssu.opensource.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ssu.opensource.exception.code.BusinessErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class BusinessException extends RuntimeException {
+    private final BusinessErrorCode errorCode;
+}

--- a/src/main/java/ssu/opensource/exception/ForbiddenException.java
+++ b/src/main/java/ssu/opensource/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package ssu.opensource.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ssu.opensource.exception.code.ForbiddenErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class ForbiddenException extends RuntimeException {
+    private final ForbiddenErrorCode errorCode;
+}

--- a/src/main/java/ssu/opensource/exception/IllegalArgumentException.java
+++ b/src/main/java/ssu/opensource/exception/IllegalArgumentException.java
@@ -1,0 +1,11 @@
+package ssu.opensource.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ssu.opensource.exception.code.IllegalArgumentErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class IllegalArgumentException extends RuntimeException {
+    private final IllegalArgumentErrorCode errorCode;
+}

--- a/src/main/java/ssu/opensource/exception/NotFoundException.java
+++ b/src/main/java/ssu/opensource/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package ssu.opensource.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ssu.opensource.exception.code.NotFoundErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class NotFoundException extends RuntimeException{
+    private final NotFoundErrorCode errorCode;
+}

--- a/src/main/java/ssu/opensource/exception/UnAuthorizedException.java
+++ b/src/main/java/ssu/opensource/exception/UnAuthorizedException.java
@@ -1,0 +1,11 @@
+package ssu.opensource.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ssu.opensource.exception.code.UnAuthorizedErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class UnAuthorizedException extends RuntimeException {
+    private final UnAuthorizedErrorCode errorCode;
+}

--- a/src/main/java/ssu/opensource/exception/code/BusinessErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/BusinessErrorCode.java
@@ -1,0 +1,18 @@
+package ssu.opensource.exception.code;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BusinessErrorCode implements DefaultErrorCode{
+    BUSINESS_TEST(HttpStatus.OK,"conflict","선착순 마감됐어요"),
+    ;
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/ssu/opensource/exception/code/DefaultErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/DefaultErrorCode.java
@@ -1,0 +1,9 @@
+package ssu.opensource.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface DefaultErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/ssu/opensource/exception/code/ForbiddenErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/ForbiddenErrorCode.java
@@ -1,0 +1,19 @@
+package ssu.opensource.exception.code;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ForbiddenErrorCode implements DefaultErrorCode{
+
+    FORBIDDEN(HttpStatus.FORBIDDEN, "error", "접근 권한이 없습니다."),
+    ;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ssu/opensource/exception/code/IllegalArgumentErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/IllegalArgumentErrorCode.java
@@ -1,0 +1,18 @@
+package ssu.opensource.exception.code;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum IllegalArgumentErrorCode implements DefaultErrorCode {
+    INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, "error", "인자의 형식이 올바르지 않습니다."),
+    ;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ssu/opensource/exception/code/InternalServerErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/InternalServerErrorCode.java
@@ -1,0 +1,18 @@
+package ssu.opensource.exception.code;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum InternalServerErrorCode implements DefaultErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "error", "서버 내부 오류입니다."),
+    ;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ssu/opensource/exception/code/NotFoundErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/NotFoundErrorCode.java
@@ -1,0 +1,18 @@
+package ssu.opensource.exception.code;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotFoundErrorCode implements DefaultErrorCode{
+    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "error", "존재하지 않는 API입니다."),
+    ;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ssu/opensource/exception/code/UnAuthorizedErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/UnAuthorizedErrorCode.java
@@ -1,0 +1,19 @@
+package ssu.opensource.exception.code;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UnAuthorizedErrorCode implements DefaultErrorCode{
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다.")
+
+    ;
+
+    @JsonIgnore
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #1 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
ResponseDto를 사용해서 봉투패턴을 만들었습니다.
```java
public record ResponseDto<T> (
        String code,
        T data,
        String message
) {
    public static <T> ResponseDto<T> success(final T data) {
        return new ResponseDto<>("success", data, null);
    }

    public static <T> ResponseDto<T> fail(DefaultErrorCode code) {
        return new ResponseDto<>(code.getCode(), null, code.getMessage());
    }
}
```
성공했을 때는 code에 success를 반환 후 data에 반환할 dto만 넣어주도록 하였고,
실패했을 때는 code에 에러 code(error, conflict)를 넣어주고, 이에 따른 message도 불러와서 넣어주었습니다.

하지만 이 봉투패턴을 사용할 때는 원래

```java
@GetMapping("/test/success")
public ResponseDto<TestDto> testSuccess() {
    return new ResponseDto(TestDto.builder().content("success").build());
}
```
이런 식으로 반환값에 ResponseDto를 붙여서 사용했습니다. 하지만 ResponseEntity를 직접 사용하지 않으니 REST 규칙에 안 맞는 경우가 생기는 것 같아서(created 시 Loacation 헤더에 id 넣기, 204 No content 등) 이를 ResponseEntity에 자동으로 담기도록 구현했습니다.

```java
@RestControllerAdvice
public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {
    @Override
    public boolean supports(MethodParameter returnType, @NonNull Class converterType) {
        return !(returnType.getParameterType() == ResponseDto.class)
                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
    }

    @Override
    public Object beforeBodyWrite(
            Object body,
            @NonNull MethodParameter returnType,
            @NonNull MediaType selectedContentType,
            @NonNull Class selectedConverterType,
            @NonNull ServerHttpRequest request,
            @NonNull ServerHttpResponse response
    ) {
        if (body instanceof DefaultErrorCode)
            return ResponseDto.fail((DefaultErrorCode) body);
        return ResponseDto.success(body);
    }
}
```

ResponseEntityAdvice를 implements 하여 함수들을 덮어써줍니다. 내장 함수를 오버라이딩해서 사용하면 ResponseEntity를 불러와서 사용할 때 자동으로 봉투패턴이 들어가게 됩니다.

ex>
```java
    @GetMapping("/test/success")
    public ResponseEntity<TestDto> testSuccess() {
        return ResponseEntity.ok(TestDto.builder().content("success").build());
    }
```

<img width="1023" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/103352114/8d887ab0-305f-422f-9458-2f234a925195">


GlobalExceptionHandler를 이용해서 Exception들을 커스텀해주었습니다.
```java
@Slf4j
@RestControllerAdvice
public class GlobalExceptionHandler {

    // 요청은 정상이나 비즈니스 중 실패가 있는 경우
    @ExceptionHandler(BusinessException.class)
    public ResponseEntity<BusinessErrorCode> handleBusinessException(BusinessException e) {
        log.error("GlobalExceptionHandler catch BusinessException : {}", e.getErrorCode().getMessage());
        return ResponseEntity
                .status(e.getErrorCode().getHttpStatus())
                .body(e.getErrorCode());
    }

    // DB에서 데이터를 찾지 못한 경우
    @ExceptionHandler(NotFoundException.class)
    public ResponseEntity<NotFoundErrorCode> handleNotFoundException(NotFoundException e){
        log.error("GlobalExceptionHandler catch NotFoundException : {}", e.getErrorCode().getMessage());
        return ResponseEntity
                .status(e.getErrorCode().getHttpStatus())
                .body(e.getErrorCode());
    }

    // 존재하지 않는 요청에 대한 예외
    @ExceptionHandler(value={NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
    public ResponseEntity<NotFoundErrorCode> handleNoPageFoundException(Exception e) {
        log.error("GlobalExceptionHandler catch NoHandlerFoundException : {}", e.getMessage());
        return ResponseEntity
                .status(NotFoundErrorCode.NOT_FOUND_END_POINT.getHttpStatus())
                .body(NotFoundErrorCode.NOT_FOUND_END_POINT);
    }

    // 기본 예외
    @ExceptionHandler(Exception.class)
    public ResponseEntity<InternalServerErrorCode> handleException(Exception e) {
        log.error("handleException() in GlobalExceptionHandler throw Exception : {}", e.getMessage());
        return ResponseEntity
                .status(InternalServerErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                .body(InternalServerErrorCode.INTERNAL_SERVER_ERROR);
    }

    // 유효하지 않은 인자가 들어온 경우 (@Valid 사용 시 수행)
    @ExceptionHandler(MethodArgumentNotValidException.class)
    public ResponseEntity<IllegalArgumentErrorCode> handleException(MethodArgumentNotValidException e) {
        log.error("handleException() in GlobalExceptionHandler throw MethodArgumentNotValidException : {}", e.getMessage());
        return ResponseEntity
                .status(IllegalArgumentErrorCode.INVALID_ARGUMENTS.getHttpStatus())
                .body(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
    }

    //권한이 없는 경우
    @ExceptionHandler(ForbiddenException.class)
    public ResponseEntity<ForbiddenErrorCode> handleException(ForbiddenException e) {
        log.error("handleException() in GlobalExceptionHandler throw ForbiddenException : {}", e.getMessage());
        return ResponseEntity
                .status(ForbiddenErrorCode.FORBIDDEN.getHttpStatus())
                .body(ForbiddenErrorCode.FORBIDDEN);
    }
}
```
저희 프로젝트에서 나올 것  같은 에러들을 핸들링해주었고, 커스텀 Exception들은 수가 많기 때문에 생략하겠습니다.
ex>
<img width="1018" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/103352114/f98999c9-de65-4433-99da-ec27c62b905c">
<img width="1021" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/103352114/3fc396f4-fd2e-42d3-965e-aae1aaf3a4a6">
<img width="1029" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/103352114/d8089a9d-9b14-4d2b-9523-3cea9f5c1066">
<img width="1002" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/103352114/637650a9-df8b-4947-b569-debbdfee9260">

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
궁금한 거 있으면 다 물어봐주세요!!