### PR TITLE
[feat] security 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,14 @@ dependencies {
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 dependencyManagement {

--- a/src/main/java/ssu/opensource/advice/GlobalExceptionHandler.java
+++ b/src/main/java/ssu/opensource/advice/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import ssu.opensource.exception.BusinessException;
 import ssu.opensource.exception.ForbiddenException;
 import ssu.opensource.exception.NotFoundException;
+import ssu.opensource.exception.UnAuthorizedException;
 import ssu.opensource.exception.code.*;
 
 @Slf4j
@@ -65,6 +66,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ForbiddenException.class)
     public ResponseEntity<ForbiddenErrorCode> handleException(ForbiddenException e) {
         log.error("handleException() in GlobalExceptionHandler throw ForbiddenException : {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(e.getErrorCode());
+    }
+
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ResponseEntity<UnAuthorizedErrorCode> handleException(UnAuthorizedException e) {
+        log.error("handleException() in GlobalExceptionHandler throw UnAuthorizedException : {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());

--- a/src/main/java/ssu/opensource/annotation/UserId.java
+++ b/src/main/java/ssu/opensource/annotation/UserId.java
@@ -1,0 +1,14 @@
+package ssu.opensource.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression="T(ssu.opensource.utils.JwtUtil).checkPrincipal(#this)")
+public @interface UserId {
+}

--- a/src/main/java/ssu/opensource/constant/AuthConstant.java
+++ b/src/main/java/ssu/opensource/constant/AuthConstant.java
@@ -1,0 +1,19 @@
+package ssu.opensource.constant;
+
+public class AuthConstant {
+    public static final String USER_ID_CLAIM_NAME = "uid";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String ANONYMOUS_USER = "anonymousUser";
+    public static final String[] AUTH_WHITELIST = {
+            "/actuator/health",
+            "/api/auth/login/google/**",
+            "/api/auth/login/google",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/api/test/token/**",
+    };
+    private AuthConstant() {
+    }
+}
+

--- a/src/main/java/ssu/opensource/controller/TestController.java
+++ b/src/main/java/ssu/opensource/controller/TestController.java
@@ -1,0 +1,29 @@
+package ssu.opensource.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ssu.opensource.annotation.UserId;
+import ssu.opensource.dto.test.TestDto;
+import ssu.opensource.dto.test.TestInput;
+import ssu.opensource.utils.JwtUtil;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class TestController {
+
+    private final JwtUtil jwtUtil;
+
+    @GetMapping("/test/security")
+    public ResponseEntity<TestDto> testSecurity(
+            @UserId final Long userId,
+            @Valid @RequestBody final TestInput testInput
+    ) {
+        return ResponseEntity.ok(TestDto.builder().content(testInput.name() + " " + userId).build());
+    }
+}

--- a/src/main/java/ssu/opensource/dto/auth/JwtTokensDto.java
+++ b/src/main/java/ssu/opensource/dto/auth/JwtTokensDto.java
@@ -1,0 +1,10 @@
+package ssu.opensource.dto.auth;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokensDto(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/ssu/opensource/dto/test/TestDto.java
+++ b/src/main/java/ssu/opensource/dto/test/TestDto.java
@@ -1,0 +1,10 @@
+package ssu.opensource.dto.test;
+
+
+import lombok.Builder;
+
+@Builder
+public record TestDto(
+        String content
+) {
+}

--- a/src/main/java/ssu/opensource/dto/test/TestInput.java
+++ b/src/main/java/ssu/opensource/dto/test/TestInput.java
@@ -1,0 +1,10 @@
+package ssu.opensource.dto.test;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TestInput(
+        @NotBlank
+        String name,
+        String email
+) {
+}

--- a/src/main/java/ssu/opensource/exception/code/BusinessErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/BusinessErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum BusinessErrorCode implements DefaultErrorCode{
-    BUSINESS_TEST(HttpStatus.OK,"conflict","선착순 마감됐어요"),
+    WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, "error", "잘못된 요청입니다."),
     ;
     @JsonIgnore
     private final HttpStatus httpStatus;

--- a/src/main/java/ssu/opensource/exception/code/UnAuthorizedErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/UnAuthorizedErrorCode.java
@@ -8,8 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum UnAuthorizedErrorCode implements DefaultErrorCode{
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다.")
-
+    TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "error", "만료된 토큰입니다."),
+    TOKEN_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "error", "인증 토큰이 존재하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다."),
+    TOKEN_TYPE_ERROR(HttpStatus.UNAUTHORIZED, "error", "토큰 타입이 잘못되거나 제공되지 않았습니다."),
+    TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "error", "잘못된 형식의 토큰입니다."),
+    TOKEN_UNSUPPORTED_ERROR(HttpStatus.UNAUTHORIZED, "error", "지원되지 않는 토큰입니다."),
     ;
 
     @JsonIgnore

--- a/src/main/java/ssu/opensource/security/config/SecurityConfig.java
+++ b/src/main/java/ssu/opensource/security/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package ssu.opensource.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import ssu.opensource.constant.AuthConstant;
+import ssu.opensource.security.filter.JwtAuthenticationFilter;
+import ssu.opensource.security.filter.JwtExceptionFilter;
+import ssu.opensource.security.handler.JwtAuthenticationEntryPoint;
+import ssu.opensource.utils.JwtUtil;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(registry ->
+                        registry
+                                .requestMatchers(AuthConstant.AUTH_WHITELIST).permitAll()
+                                .anyRequest().authenticated()
+                )
+                .exceptionHandling((exceptionHandling) ->
+                        exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                )
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtUtil),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(
+                        new JwtExceptionFilter(),
+                        JwtAuthenticationFilter.class)
+                .getOrBuild();
+    }
+}

--- a/src/main/java/ssu/opensource/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/ssu/opensource/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package ssu.opensource.security.filter;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import ssu.opensource.constant.AuthConstant;
+import ssu.opensource.security.info.UserAuthentication;
+import ssu.opensource.utils.JwtUtil;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull final HttpServletRequest request,
+            @NonNull final HttpServletResponse response,
+            @NonNull final FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String token = getJwtFromRequest(request);    //헤더에서 토큰 찾기
+        if (StringUtils.hasText(token)) {   //토큰 있으면 토큰으로부터 유저 정보 가져와서 인증 객체 생성
+            log.info("====================token: {}", token);
+            Claims claims = jwtUtil.getTokenBody(token);
+            log.info("====================claim: {}", claims);
+            Long userId = claims.get(AuthConstant.USER_ID_CLAIM_NAME, Long.class);
+            UserAuthentication authentication = UserAuthentication.createUserAuthentication(userId);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);    //다음 필터로 넘기기
+    }
+
+    private String getJwtFromRequest(final HttpServletRequest request) {
+        String bearerToken = request.getHeader(AuthConstant.AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(AuthConstant.BEARER_PREFIX)) {
+            return bearerToken.substring(AuthConstant.BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/ssu/opensource/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/ssu/opensource/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,62 @@
+package ssu.opensource.security.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import ssu.opensource.exception.BusinessException;
+import ssu.opensource.exception.code.DefaultErrorCode;
+import ssu.opensource.exception.code.InternalServerErrorCode;
+import ssu.opensource.exception.code.UnAuthorizedErrorCode;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull final HttpServletRequest request,
+            @NonNull final HttpServletResponse response,
+            @NonNull final FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (MalformedJwtException e) {
+            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_MALFORMED_ERROR, e);
+        } catch (IllegalArgumentException e) {
+            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_TYPE_ERROR, e);
+        } catch (ExpiredJwtException e) {
+            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_EXPIRED_ERROR, e);
+        } catch (UnsupportedJwtException e) {
+            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_UNSUPPORTED_ERROR, e);
+        } catch (JwtException e) {
+            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_UNKNOWN_ERROR, e);
+        } catch (BusinessException e) {
+            handleException(request, response, filterChain, e.getErrorCode(), e);
+        } catch (Exception e) {
+            handleException(request, response, filterChain, InternalServerErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    private void handleException(   //예외 처리
+                                    final HttpServletRequest request,
+                                    final HttpServletResponse response,
+                                    final FilterChain filterChain,
+                                    final DefaultErrorCode errorCode,
+                                    final Exception e
+    ) throws ServletException, IOException {
+        log.error(e.getMessage(), e);
+        request.setAttribute("exception", errorCode);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/ssu/opensource/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/ssu/opensource/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package ssu.opensource.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import ssu.opensource.dto.common.ResponseDto;
+import ssu.opensource.exception.code.BusinessErrorCode;
+import ssu.opensource.exception.code.DefaultErrorCode;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {  //인증 실패시 처리
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final AuthenticationException authException
+    ) throws IOException {
+        DefaultErrorCode errorCode = (DefaultErrorCode) request.getAttribute("exception");
+        if (errorCode == null)
+            errorCode = BusinessErrorCode.WRONG_ENTRY_POINT;
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(ResponseDto.fail(errorCode))
+        );
+    }
+}

--- a/src/main/java/ssu/opensource/security/info/UserAuthentication.java
+++ b/src/main/java/ssu/opensource/security/info/UserAuthentication.java
@@ -1,0 +1,20 @@
+package ssu.opensource.security.info;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public UserAuthentication(
+            final Object principal,
+            final Object credentials,
+            final Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    public static UserAuthentication createUserAuthentication(final Long userId) {
+        return new UserAuthentication(userId, null, null);
+    }
+}

--- a/src/main/java/ssu/opensource/utils/JwtUtil.java
+++ b/src/main/java/ssu/opensource/utils/JwtUtil.java
@@ -1,0 +1,82 @@
+package ssu.opensource.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import ssu.opensource.constant.AuthConstant;
+import ssu.opensource.dto.auth.JwtTokensDto;
+import ssu.opensource.exception.UnAuthorizedException;
+import ssu.opensource.exception.code.UnAuthorizedErrorCode;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil implements InitializingBean {
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expire-period}")
+    @Getter
+    private Integer accessTokenExpirePeriod;
+
+    @Value("${jwt.refresh-token-expire-period}")
+    @Getter
+    private Integer refreshTokenExpirePeriod;
+
+    private Key key;
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public JwtTokensDto generateTokens(final Long id) {
+        return JwtTokensDto.builder()
+                .accessToken(generateToken(id, accessTokenExpirePeriod))
+                .refreshToken(generateToken(id, refreshTokenExpirePeriod))
+                .build();
+    }
+
+    private String generateToken(final Long id, final Integer expirePeriod) {
+        Claims claims = Jwts.claims();
+        claims.put(AuthConstant.USER_ID_CLAIM_NAME, id);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.JWT_TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expirePeriod))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public Claims getTokenBody(final String token){
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public static Object checkPrincipal(final Object principal) {
+        if (AuthConstant.ANONYMOUS_USER.equals(principal)) {
+            throw new UnAuthorizedException(UnAuthorizedErrorCode.UNAUTHORIZED);
+        }
+        return principal;
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #3 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
security를 적용하여 token을 이용한 유저 인증을 할 수 있도록 합니다.
<img width="762" alt="image" src="https://github.com/user-attachments/assets/0f18269b-ca84-491f-be2d-fd0d1c6a4a40">

spring security를 적용하면 이렇게 많은 filter들을 filterChain을 이용해서 거치게 됩니다. 저희는 이 중 UsernamePasswordAuthenticationFilter 앞에 token을 검증하는 두 개의 필터를 적용했습니다. token이 올바르게 들어오는지 예외를 잡아주는 JwtExceptionFilter, token을 이용해서 사용자의 인증 객체를 생성해주는 JwtAuthenticationFilter를 구현했습니다.

### SecurityConfig
```java
@Configuration
@EnableWebSecurity
@RequiredArgsConstructor
public class SecurityConfig {

    private final JwtUtil jwtUtil;
    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;

    @Bean
    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        return http
                // CSRF 보호 비 활성화
                .csrf(AbstractHttpConfigurer::disable)
                // HTTP Basic 인증 비 활성화
                .httpBasic(AbstractHttpConfigurer::disable)
                // 폼 로그인 비 활성화
                .formLogin(AbstractHttpConfigurer::disable)
                // 세션 관리 설정: 세션을 사용 하지 않음 (Stateless)
                .sessionManagement((sessionManagement) ->
                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                )
                // 요청 인증 설정
                .authorizeHttpRequests(registry ->
                        registry
                                // 화이트 리스트 경로는 인증 없이 접근 허용
                                .requestMatchers(AuthConstant.AUTH_WHITELIST).permitAll()
                                // 그 외의 모든 요청은 인증 필요
                                .anyRequest().authenticated()
                )
                // 예외 처리 설정: 인증 실패 시 커스텀 엔트리 포인트 사용
                .exceptionHandling((exceptionHandling) ->
                        exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint)
                )
                // 필터 체인에 JwtAuthenticationFilter 추가: UsernamePasswordAuthenticationFilter 앞에 추가
                .addFilterBefore(
                        new JwtAuthenticationFilter(jwtUtil),
                        UsernamePasswordAuthenticationFilter.class)
                // 필터 체인에 JwtExceptionFilter 추가: JwtAuthenticationFilter 앞에 추가
                .addFilterBefore(
                        new JwtExceptionFilter(),
                        JwtAuthenticationFilter.class)
                .getOrBuild();
    }

}
```

주석을 달아놨으니 설명은 생략하겠습니다.

### JwtExceptionFilter
```java
@Slf4j
@RequiredArgsConstructor
public class JwtExceptionFilter extends OncePerRequestFilter {

    @Override
    protected void doFilterInternal(
            @NonNull final HttpServletRequest request,
            @NonNull final HttpServletResponse response,
            @NonNull final FilterChain filterChain
    ) throws ServletException, IOException {
        try {
            filterChain.doFilter(request, response);
        } catch (MalformedJwtException e) {
            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_MALFORMED_ERROR, e);
        } catch (IllegalArgumentException e) {
            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_TYPE_ERROR, e);
        } catch (ExpiredJwtException e) {
            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_EXPIRED_ERROR, e);
        } catch (UnsupportedJwtException e) {
            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_UNSUPPORTED_ERROR, e);
        } catch (JwtException e) {
            handleException(request, response, filterChain, UnAuthorizedErrorCode.TOKEN_UNKNOWN_ERROR, e);
        } catch (Exception e) {
            handleException(request, response, filterChain, InternalServerErrorCode.INTERNAL_SERVER_ERROR, e);
        }
    }

    private void handleException(   //예외 처리
            final HttpServletRequest request,
            final HttpServletResponse response,
            final FilterChain filterChain,
            final DefaultErrorCode errorCode,
            final Exception e
    ) throws ServletException, IOException {
        log.error("FilterException throw {} Exception : {}", e.getClass().getSimpleName(), e.getMessage());
        request.setAttribute("exception", errorCode);
        filterChain.doFilter(request, response);
    }
}
```

filter는 dofilter를 통해서 다음 필터로 이동하게 되는데, 그 과정에서 나는 토큰 관련 에러들이 터진다면 이를 잡아주고, 에러들을 request에 저장한 후 다음 filter로 이동하도록 합니다. 에러를 터뜨리고 dofilter없이 바로 끝내도 되지 않겠냐라는 생각이 드실 수 있지만, 유저 인증을 진행하지 않는 api들(white list에 넣은 api들)도 dofilter를 통해서 모든 필터들을 통과하기 때문에, shouldNotFilter 등과 같은 함수를 직접 짜지 않는 한 dofilter를 무조건 해줍니다.

### JwtAuthenticationFilter
```java
@Slf4j
@RequiredArgsConstructor
public class JwtAuthenticationFilter extends OncePerRequestFilter {

    private final JwtUtil jwtUtil;

    @Override
    protected void doFilterInternal(
            @NonNull final HttpServletRequest request,
            @NonNull final HttpServletResponse response,
            @NonNull final FilterChain filterChain
    ) throws ServletException, IOException {
        final String token = getJwtFromRequest(request);    //헤더에서 토큰 찾기
        if (StringUtils.hasText(token)) {   //토큰 있으면 토큰으로부터 유저 정보 가져와서 인증 객체 생성
            Claims claims = jwtUtil.getTokenBody(token);
            Long userId = claims.get(AuthConstant.USER_ID_CLAIM_NAME, Long.class);
            UserAuthentication authentication = UserAuthentication.createUserAuthentication(userId);
            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
            SecurityContextHolder.getContext().setAuthentication(authentication);
        }
        filterChain.doFilter(request, response);    //다음 필터로 넘기기
    }

    private String getJwtFromRequest(final HttpServletRequest request) {
       String bearerToken = request.getHeader(AuthConstant.AUTHORIZATION_HEADER);
       if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(AuthConstant.BEARER_PREFIX)) {
           return bearerToken.substring(AuthConstant.BEARER_PREFIX.length());
       }
       return null;
    }
}
```

헤더의 토큰을 찾고, 토큰을 이용하여 유저의 인증 객체를 생성해줘서 성공적인 인증과정을 거치도록 해주는 filter입니다.
인증 객체는 Authentication을 userId를 이용해서 만들어준 뒤, ContextHolder에 Authentication을 저장해줘서 해당 유저의 인증 객체를 생성해준다고 생각해주시면 됩니다.

### JwtAuthenticationEntryPoint
```java
@Component
public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {  //인증 실패시 처리
    private final ObjectMapper objectMapper = new ObjectMapper();

    @Override
    public void commence(
            final HttpServletRequest request,
            final HttpServletResponse response,
            final AuthenticationException authException
    ) throws IOException {
        DefaultErrorCode errorCode = (DefaultErrorCode) request.getAttribute("exception");
        if (errorCode == null)
            errorCode = UnAuthorizedErrorCode.UNAUTHORIZED;
        response.setContentType("application/json");
        response.setCharacterEncoding("UTF-8");
        response.setStatus(errorCode.getHttpStatus().value());
        response.getWriter().write(
                objectMapper.writeValueAsString(ResponseDto.fail(errorCode))
        );
    }
}
```

filter를 진행했을 때 인증에 실패한 경우를 처리해줍니다. 이 전에 에러를 잡았었다면, 그 에러를 주고 아닌 경우 인증되지 않은 사용자라는 에러를 만들어서 반환해줍니다.

### @UserId
UserId라는 어노테이션을 만들어서 토큰이 들어올 경우 자동으로 userId 파라미터에 유저의 id를 담아올 수 있도록 했습니다.
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/103352114/5c433c07-cbf6-4e45-939a-cc7bf1f1fc7b)
이렇게 파라미터에 userId를 선언해주면 토큰을 넣은 호출에는 토큰에 맞는 유저의 id를 반환해줄 수 있습니다.
<img width="1015" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/103352114/a41263cd-b868-43f8-a1f3-5be77d716fab">
1로 잘 받아오는 것을 알 수 있습니다.


## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
궁금한 거 있으면 물어보세요!