### PR TITLE
[feat] 구글 소셜 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.postgresql:postgresql'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// redis 설치 후 주석 해제하기
 	// implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/ssu/opensource/controller/AuthController.java
+++ b/src/main/java/ssu/opensource/controller/AuthController.java
@@ -1,0 +1,42 @@
+package ssu.opensource.controller;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ssu.opensource.annotation.UserId;
+import ssu.opensource.dto.auth.JwtTokensDto;
+import ssu.opensource.service.auth.AuthService;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/login/google")
+    public ResponseEntity<Void> googleLogin(
+            @RequestParam final String code
+    ) throws IOException {
+        authService.googleLogin(code);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/auth/re-issue")
+    public ResponseEntity<JwtTokensDto> reissueToken(
+            @RequestHeader("Authorization") final String refreshToken
+    ){
+        return ResponseEntity.ok(authService.reissueToken(refreshToken));
+    }
+
+    @DeleteMapping("/auth/logout")
+    public ResponseEntity<?> logout(
+            @UserId final Long userId
+    ){
+        authService.logout(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ssu/opensource/domain/Token.java
+++ b/src/main/java/ssu/opensource/domain/Token.java
@@ -1,0 +1,26 @@
+package ssu.opensource.domain;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value="token", timeToLive = 60 * 60 * 24 * 14)
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Token {
+
+    @Id
+    private Long id;
+    @Indexed
+    private String refreshToken;
+
+    @Builder
+    public Token(Long id, String refreshToken) {
+        this.id = id;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/ssu/opensource/domain/User.java
+++ b/src/main/java/ssu/opensource/domain/User.java
@@ -24,7 +24,7 @@ public class User {
     @Column(name="email", nullable = false)
     private String email;
 
-    @Column(name="serial_id", nullable = false)
+    @Column(name="serial_id", nullable = false, unique = true)
     private String serialId;
 
     @Column(name="google_token")
@@ -40,10 +40,10 @@ public class User {
     private List<Task> tasks;
 
     @Builder
-    public User(String name, String email, String serialId) {
+    public User(String serialId, String name, String email) {
+        this.serialId = serialId;
         this.name = name;
         this.email = email;
-        this.serialId = serialId;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/ssu/opensource/dto/auth/JwtTokensDto.java
+++ b/src/main/java/ssu/opensource/dto/auth/JwtTokensDto.java
@@ -7,4 +7,7 @@ public record JwtTokensDto(
         String accessToken,
         String refreshToken
 ) {
+    public static JwtTokensDto of(String accessToken, String refreshToken) {
+        return new JwtTokensDto(accessToken, refreshToken);
+    }
 }

--- a/src/main/java/ssu/opensource/exception/code/NotFoundErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/NotFoundErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum NotFoundErrorCode implements DefaultErrorCode{
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "error", "존재하지 않는 API입니다."),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "error","리프레시 토큰을 찾을 수 없습니다."),
+
     ;
 
     @JsonIgnore

--- a/src/main/java/ssu/opensource/exception/code/UnAuthorizedErrorCode.java
+++ b/src/main/java/ssu/opensource/exception/code/UnAuthorizedErrorCode.java
@@ -8,12 +8,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum UnAuthorizedErrorCode implements DefaultErrorCode{
-    TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "error", "만료된 토큰입니다."),
-    TOKEN_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "error", "인증 토큰이 존재하지 않습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다."),
     TOKEN_TYPE_ERROR(HttpStatus.UNAUTHORIZED, "error", "토큰 타입이 잘못되거나 제공되지 않았습니다."),
-    TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "error", "잘못된 형식의 토큰입니다."),
-    TOKEN_UNSUPPORTED_ERROR(HttpStatus.UNAUTHORIZED, "error", "지원되지 않는 토큰입니다."),
+    TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "error", "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "error", "만료된 토큰입니다."),
+    TOKEN_UNSUPPORTED_ERROR(HttpStatus.UNAUTHORIZED, "error", "지원하지 않는 토큰입니다."),
+    TOKEN_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "error", "알 수 없는 토큰입니다."),
+    REFRESH_TOKEN_INVALID_ERROR(HttpStatus.UNAUTHORIZED,"error","유효하지 않은 Refresh Token 입니다.")
     ;
 
     @JsonIgnore

--- a/src/main/java/ssu/opensource/feign/SuccessCode.java
+++ b/src/main/java/ssu/opensource/feign/SuccessCode.java
@@ -1,0 +1,18 @@
+package ssu.opensource.feign;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessCode {
+    POST_LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
+    POST_REISSUE_SUCCESS(HttpStatus.OK, "액세스 토큰 재발급에 성공했습니다.."),
+    POST_LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공하였습니다.")
+    ;
+
+    public final HttpStatus httpStatus;
+    public final String message;
+}

--- a/src/main/java/ssu/opensource/feign/config/FeignConfig.java
+++ b/src/main/java/ssu/opensource/feign/config/FeignConfig.java
@@ -1,0 +1,10 @@
+package ssu.opensource.feign.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+import ssu.opensource.OpensourceApplication;
+
+@EnableFeignClients(basePackageClasses = OpensourceApplication.class)
+@Configuration
+public class FeignConfig {
+}

--- a/src/main/java/ssu/opensource/feign/google/GoogleAuthClient.java
+++ b/src/main/java/ssu/opensource/feign/google/GoogleAuthClient.java
@@ -1,0 +1,16 @@
+package ssu.opensource.feign.google;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "customGoogleAuthApiClient", url = "https://oauth2.googleapis.com/token")
+public interface GoogleAuthClient {
+    @PostMapping
+    GoogleTokenResponse googleAuth(
+            @RequestParam(name="code") String code,
+            @RequestParam(name="clientId") String clientId,
+            @RequestParam(name="clientSecret") String clientSecret,
+            @RequestParam(name="redirectUri") String redirectUri,
+            @RequestParam(name="grantType") String grantType);
+}

--- a/src/main/java/ssu/opensource/feign/google/GoogleInfoClient.java
+++ b/src/main/java/ssu/opensource/feign/google/GoogleInfoClient.java
@@ -1,0 +1,13 @@
+package ssu.opensource.feign.google;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name="GoogleInfoClient", url = "https://www.googleapis.com/oauth2/v3/userinfo")
+public interface GoogleInfoClient {
+    @GetMapping
+    GoogleUserInfoResponse googleInfo(
+            @RequestHeader("Authorization") String accessToken
+    );
+}

--- a/src/main/java/ssu/opensource/feign/google/GoogleTokenResponse.java
+++ b/src/main/java/ssu/opensource/feign/google/GoogleTokenResponse.java
@@ -1,0 +1,15 @@
+package ssu.opensource.feign.google;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GoogleTokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static GoogleTokenResponse of(String accessToken, String refreshToken) {
+        return new GoogleTokenResponse(accessToken, refreshToken);
+    }
+
+}

--- a/src/main/java/ssu/opensource/feign/google/GoogleUserInfoResponse.java
+++ b/src/main/java/ssu/opensource/feign/google/GoogleUserInfoResponse.java
@@ -1,0 +1,18 @@
+package ssu.opensource.feign.google;
+
+public record GoogleUserInfoResponse(
+        String sub,
+        String name,
+        String givenName,
+        String familyName,
+        String picture,
+        String email,
+        String emailVerified,
+        String local
+
+) {
+    public static GoogleUserInfoResponse of(String sub, String name, String givenName, String familyName, String picture,
+                                            String email, String emailVerified, String local) {
+        return new GoogleUserInfoResponse(sub, name, givenName, familyName, picture, email, emailVerified, local);
+    }
+}

--- a/src/main/java/ssu/opensource/repository/TokenRepository.java
+++ b/src/main/java/ssu/opensource/repository/TokenRepository.java
@@ -1,0 +1,12 @@
+package ssu.opensource.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import ssu.opensource.domain.Token;
+
+import java.util.Optional;
+
+public interface TokenRepository extends CrudRepository<Token, Long> {
+    // Optional은 메소드의 결과가 null이 될 수 있으며, null에 의해 오류가 발생할 가능성이 매우 높을 때 반환값으로만 사용
+    Optional<Token> findByRefreshToken(final String refreshToken);
+    Optional<Token> findById(final Long id);
+}

--- a/src/main/java/ssu/opensource/repository/UserRepository.java
+++ b/src/main/java/ssu/opensource/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package ssu.opensource.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ssu.opensource.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findBySerialIdAndEmail(final String serialId, final String email);
+}

--- a/src/main/java/ssu/opensource/service/auth/AuthService.java
+++ b/src/main/java/ssu/opensource/service/auth/AuthService.java
@@ -1,0 +1,81 @@
+package ssu.opensource.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import ssu.opensource.domain.Token;
+import ssu.opensource.domain.User;
+import ssu.opensource.dto.auth.JwtTokensDto;
+import ssu.opensource.feign.google.GoogleAuthClient;
+import ssu.opensource.feign.google.GoogleInfoClient;
+import ssu.opensource.feign.google.GoogleTokenResponse;
+import ssu.opensource.feign.google.GoogleUserInfoResponse;
+import ssu.opensource.service.token.TokenRemover;
+import ssu.opensource.service.token.TokenRetriever;
+import ssu.opensource.service.token.TokenSaver;
+import ssu.opensource.service.user.UserRetriever;
+import ssu.opensource.utils.JwtUtil;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Value;
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUrl;
+
+    private final GoogleAuthClient googleAuthClient;
+    private final GoogleInfoClient googleInfoClient;
+    private final JwtUtil jwtUtil;
+    private final TokenRetriever tokenRetriever;
+    private final UserRetriever userRetriever;
+    private final TokenSaver tokenSaver;
+    private final TokenRemover tokenRemover;
+
+    @Transactional
+    public JwtTokensDto reissueToken(final String refreshToken){
+        String token = refreshToken.substring("Bearer ".length());
+        Long userId = tokenRetriever.findMemberIdByRefreshToken(token);
+        JwtTokensDto tokensDto = jwtUtil.generateTokens(userId);
+        tokenSaver.save(Token.builder().id(userId).refreshToken(tokensDto.refreshToken()).build());
+        return tokensDto;
+    }
+
+    @Transactional
+    public void logout(final Long userId){
+        Token refreshToken = tokenRetriever.findById(userId);
+        tokenRemover.deleteToken(refreshToken);
+    }
+
+    @Transactional
+    public JwtTokensDto googleLogin(final String code)
+            throws IOException{
+        log.info("{}", code);
+        GoogleTokenResponse googleTokenResponse = googleAuthClient.googleAuth( // 구글 인증 API 호출
+                code, // 클라이언트에서 받은 인증 코드
+                //구글 API에 필요한 클라이언트 정보
+                clientId,
+                clientSecret,
+                redirectUrl,
+                //권한 부여 코드 타입
+                "authorization_code"
+        );
+        GoogleUserInfoResponse googleUserInfoResponse = googleInfoClient.googleInfo( // 구글 사용자 정보 API를 호출
+                "Bearer " + googleTokenResponse.accessToken());
+
+        User user = userRetriever.findBySerialIdAndEmailOrGet(googleUserInfoResponse.sub(), googleUserInfoResponse.name(), googleUserInfoResponse.email());
+        JwtTokensDto jwtTokensDto = jwtUtil.generateTokens(user.getId());
+        tokenSaver.save(Token.builder().id(user.getId()).refreshToken(jwtTokensDto.refreshToken()).build());
+        return jwtTokensDto;
+    }
+}

--- a/src/main/java/ssu/opensource/service/token/TokenRemover.java
+++ b/src/main/java/ssu/opensource/service/token/TokenRemover.java
@@ -1,0 +1,13 @@
+package ssu.opensource.service.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ssu.opensource.domain.Token;
+import ssu.opensource.repository.TokenRepository;
+
+@Component
+@RequiredArgsConstructor
+public class TokenRemover {
+    private final TokenRepository tokenRepository;
+    public void deleteToken(final Token token) {tokenRepository.delete(token);}
+}

--- a/src/main/java/ssu/opensource/service/token/TokenRetriever.java
+++ b/src/main/java/ssu/opensource/service/token/TokenRetriever.java
@@ -1,0 +1,27 @@
+package ssu.opensource.service.token;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ssu.opensource.domain.Token;
+import ssu.opensource.exception.NotFoundException;
+import ssu.opensource.exception.code.NotFoundErrorCode;
+import ssu.opensource.repository.TokenRepository;
+
+@Component
+@RequiredArgsConstructor
+public class TokenRetriever {
+    private final TokenRepository tokenRepository;
+
+    public Long findMemberIdByRefreshToken(final String refreshToken) {
+        return tokenRepository.findByRefreshToken(refreshToken).orElseThrow(
+                () -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_REFRESH_TOKEN)
+        ).getId();
+    }
+
+    public Token findById(final Long userId){
+        return tokenRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_REFRESH_TOKEN)
+        );
+    }
+}

--- a/src/main/java/ssu/opensource/service/token/TokenSaver.java
+++ b/src/main/java/ssu/opensource/service/token/TokenSaver.java
@@ -1,0 +1,13 @@
+package ssu.opensource.service.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ssu.opensource.domain.Token;
+import ssu.opensource.repository.TokenRepository;
+
+@Component
+@RequiredArgsConstructor
+public class TokenSaver {
+    private final TokenRepository tokenRepository;
+    public void save(final Token token) {tokenRepository.save(token);}
+}

--- a/src/main/java/ssu/opensource/service/user/UserRetriever.java
+++ b/src/main/java/ssu/opensource/service/user/UserRetriever.java
@@ -1,0 +1,17 @@
+package ssu.opensource.service.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ssu.opensource.domain.User;
+import ssu.opensource.repository.UserRepository;
+
+@Component
+@RequiredArgsConstructor
+public class UserRetriever {
+    private final UserRepository userRepository;
+    public User findBySerialIdAndEmailOrGet(final String serialId, final String name, final String email){
+        return userRepository.findBySerialIdAndEmail(serialId, email).orElseGet(
+                ()-> userRepository.save(User.builder().serialId(serialId).name(name).email(email).build())
+        );
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closes #6 

## Work Description ✏️

### Redirect
![image](https://github.com/TEAM-DAWM/NUTSHELL-SERVER/assets/128598386/25e4bdf2-87a9-4158-8dba-48d13aaa2c43)
구글 OAuth 2.0 인증 흐름을 통해 클라이언트가 구글 로그인 페이지로 리다이렉트되고, 사용자가 로그인 인증을 완료하면 구글이 인가 코드를 클라이언트의 리다이렉트 URI로 전송합니다. 클라이언트는 받은 이 인가 코드를 서버의 /login/google 엔드포인트로 전송하여 인증을 완료합니다. 

---
### 로그인
<img width="806" alt="image" src="https://github.com/user-attachments/assets/276a846e-b68c-4287-aa2d-207366cf9b5c">
받아온 인가 코드로 구글에게 accessToken을 요청하고, 받아옵니다. 이 accessToken으로 구글에게 사용자 정보를 요청하고, 받아옵니다. OpenFegin를 사용하여 구현했습니다.

---
### 토큰 재발급
<img width="812" alt="image" src="https://github.com/user-attachments/assets/6276be27-ecf0-4fe1-9a01-d03967c8b843">
refreshToken을 사용하여 accessToken을 다시 재발급 합니다.

 
---
### 로그아웃 
<img width="809" alt="image" src="https://github.com/user-attachments/assets/cb942531-6515-4532-afe3-f2b4abbcf514">
redis에 저장되어 있는 userId에 해당하는 refreshToken을 삭제해 줍니다. 이 때, 커스텀한 @UserId 어노테이션이 '매개변수로 refreshToken을 넣어주면 userId를 자동으로 찾아와' 주는 역할을 합니다.

---
### 패키지 구조
기능별로 Service의 코드를 분리하였습니다. 
find 로직은 Retriever로, delete로직은 Remover로, save 로직은 Saver로, update로직은 Update로 분리하였습니다.

---
🍀 (참고) Redis에 저장되어 있는 RefreshToken 확인해보기
    KEY값(refreshToken) 으로 되어 있는 아이들 모두 확인
<img width="821" alt="image" src="https://github.com/user-attachments/assets/c6fd2957-a8ea-436f-b3cb-b45c608112d1">
 
## Trouble Shooting ⚽️
처음에 redis에 refreshToken을 저장하는 로직을 구현할 때 redisTemplate을 사용했었는데, 이 경우는 채팅과 같이 redis를 많이 써야 할 때 최대한 효율을 내기 위한 상황일 때 사용하는 것이 좋다는 것을 알게 되었습니다. 저희 서비스에서는 단순히 redis에 토큰을 저장하고 꺼내오는 작업만 하기 때문에, TokenRepository를 만들어서 하는 방법으로 리팩토링 하였습니다~🌟
