### PR TITLE
[feat] Task 상세 조회 GET API (PR 추후 보충)

### DIFF
--- a/src/main/java/ssu/opensource/controller/TaskController.java
+++ b/src/main/java/ssu/opensource/controller/TaskController.java
@@ -1,14 +1,18 @@
 package ssu.opensource.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ssu.opensource.annotation.UserId;
+import ssu.opensource.dto.task.request.TargetDateDto;
 import ssu.opensource.dto.task.request.TaskCreateDto;
 import ssu.opensource.dto.task.request.TaskStatusDto;
+import ssu.opensource.dto.task.response.TaskDetailDto;
 import ssu.opensource.service.task.TaskService;
 
 import java.net.URI;
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,5 +51,14 @@ public class TaskController {
         return ResponseEntity.noContent().build();
     }
 
-
+    // Task 상세조회 GET API
+    @GetMapping("/tasks/{taskId}")
+    public ResponseEntity<TaskDetailDto> getTask(
+            @UserId final Long userId,
+            @PathVariable final Long taskId,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") final LocalDate targetDate
+    ){
+        TargetDateDto targetDateDto = (targetDate != null) ? new TargetDateDto(targetDate) : null;
+        return ResponseEntity.ok(taskService.getTaskDetails(userId, taskId, targetDateDto));
+    }
 }

--- a/src/main/java/ssu/opensource/dto/task/request/TargetDateDto.java
+++ b/src/main/java/ssu/opensource/dto/task/request/TargetDateDto.java
@@ -1,0 +1,11 @@
+package ssu.opensource.dto.task.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record TargetDateDto(
+        @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate targetDate
+) {
+}

--- a/src/main/java/ssu/opensource/dto/task/response/TaskDetailDto.java
+++ b/src/main/java/ssu/opensource/dto/task/response/TaskDetailDto.java
@@ -1,0 +1,25 @@
+package ssu.opensource.dto.task.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import ssu.opensource.dto.task.request.TaskCreateDto;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record TaskDetailDto(
+        String name,
+        String description,
+        TaskCreateDto.DeadLine deadLine,
+        String status,
+        TimeBlock timeBlock
+) {
+    @Builder
+    public record TimeBlock(
+            Long id,
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+            LocalDateTime startTime,
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+            LocalDateTime endTime
+    ){}
+}


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #22 

 &nbsp; 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
Task 상세 조회 GET API를 구현하였습니다.

 &nbsp; 

### TaskService


 &nbsp; 

### TImeblockRetriever

 &nbsp; 

### TimeBlockRepository
targetDate의 00시-23시59분59초 사이에 있는 timeBlock 1개를 찾아오도록 쿼리문을 작성했습니다.(targetDate내에서 한 Task는 1개의 timeBlock을 갖습니다.

