### PR TITLE
[feat] Task List 조회 API 구현

### DIFF
--- a/src/main/java/ssu/opensource/controller/TaskController.java
+++ b/src/main/java/ssu/opensource/controller/TaskController.java
@@ -1,5 +1,6 @@
 package ssu.opensource.controller;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,7 @@ import ssu.opensource.dto.task.request.TargetDateDto;
 import ssu.opensource.dto.task.request.TaskCreateDto;
 import ssu.opensource.dto.task.request.TaskStatusDto;
 import ssu.opensource.dto.task.response.TaskDetailDto;
+import ssu.opensource.dto.task.response.TasksDto;
 import ssu.opensource.dto.task.response.TodoTaskDto;
 import ssu.opensource.service.task.TaskService;
 
@@ -62,6 +64,18 @@ public class TaskController {
         TargetDateDto targetDateDto = (targetDate != null) ? new TargetDateDto(targetDate) : null;
         return ResponseEntity.ok(taskService.getTaskDetails(userId, taskId, targetDateDto));
     }
+
+    // Task 리스트 조회
+    @GetMapping("/tasks")
+    public ResponseEntity<TasksDto> getTasks(
+            @UserId final Long userId,
+            @RequestParam(required = false) final Boolean isTotal,
+            @RequestParam(required = false) final String order,
+            @RequestParam(required = false) @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul") final LocalDate targetDate
+    ){
+        return ResponseEntity.ok(taskService.getTasks(userId, isTotal, order, targetDate));
+    }
+
 
     // Task type별 리스트 조회
     @GetMapping("/tasks/today")

--- a/src/main/java/ssu/opensource/dto/task/response/TasksDto.java
+++ b/src/main/java/ssu/opensource/dto/task/response/TasksDto.java
@@ -1,0 +1,21 @@
+package ssu.opensource.dto.task.response;
+
+import lombok.Builder;
+import ssu.opensource.dto.task.request.TaskCreateDto;
+
+import java.util.List;
+
+@Builder
+public record TasksDto(
+        List<TaskDto> tasks
+) {
+    @Builder
+    public record TaskDto(
+            Long id,
+            String name,
+            TaskCreateDto.DeadLine deadLine,
+            Boolean hasDescription,
+            String status
+    ) {
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #26 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
Task List 조회 API를 구현했습니다.

Staging Area인 경우, isTotal 에 따라 전체, 지연 조회를 하고, order에 따라 정렬 기준을 다르게 나타냅니다.
TargetDate Area인 경우, 정렬을 위해 첫번째 값으로 최근에 status가 업데이트순으로 정렬하고, 그 뒤로 assign된 순으로 정렬하도록 합니다.
