### PR TITLE
[feat] 대시보드에서 기간별로 완료한 일 수, 평균 진행 중인 일 수, 평균 지연율을 조회하는 GET API 구현

### DIFF
--- a/src/main/java/ssu/opensource/controller/TaskController.java
+++ b/src/main/java/ssu/opensource/controller/TaskController.java
@@ -10,6 +10,7 @@ import ssu.opensource.dto.task.request.TargetDateDto;
 import ssu.opensource.dto.task.request.TaskCreateDto;
 import ssu.opensource.dto.task.request.TaskStatusDto;
 import ssu.opensource.dto.task.request.TaskUpdateDto;
+import ssu.opensource.dto.task.response.TaskDashboardDto;
 import ssu.opensource.dto.task.response.TaskDetailDto;
 import ssu.opensource.dto.task.response.TasksDto;
 import ssu.opensource.dto.task.response.TodoTaskDto;
@@ -96,6 +97,17 @@ public class TaskController {
     ){
         taskService.updateTask(userId, taskId, taskUpdateDto);
         return ResponseEntity.noContent().build();
+    }
+
+    // 대시보드
+    @GetMapping("/tasks/period")
+    public ResponseEntity<TaskDashboardDto> getDashBoard(
+            @UserId final Long userId,
+            @RequestParam(required = false) final LocalDate startDate,
+            @RequestParam(required = false) final LocalDate endDate,
+            @RequestParam(required = false) final Boolean isMonth
+    ){
+        return ResponseEntity.ok(taskService.getDashboard(userId, startDate, endDate, isMonth));
     }
 
 

--- a/src/main/java/ssu/opensource/dto/task/response/TaskDashboardDto.java
+++ b/src/main/java/ssu/opensource/dto/task/response/TaskDashboardDto.java
@@ -1,0 +1,11 @@
+package ssu.opensource.dto.task.response;
+
+import lombok.Builder;
+
+@Builder
+public record TaskDashboardDto(
+        int completeTasks,
+        double avgInprogressTasks,
+        double avgDeferredRate
+) {
+}

--- a/src/main/java/ssu/opensource/service/task/TaskRetriever.java
+++ b/src/main/java/ssu/opensource/service/task/TaskRetriever.java
@@ -8,6 +8,7 @@ import ssu.opensource.exception.NotFoundException;
 import ssu.opensource.exception.code.NotFoundErrorCode;
 import ssu.opensource.repository.TaskRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -55,5 +56,7 @@ public class TaskRetriever {
         return taskRepository.findAllDeferredTasksByUserWithStatus(userId);
     }
 
-
+    public Integer countAllAssignedTasksInPeriod(final Long userId, final LocalDate startDate, final LocalDate endDate){
+        return taskRepository.countAllAssignedTasksInPeriod(userId, startDate, endDate);
+    }
 }

--- a/src/main/java/ssu/opensource/service/task/TaskService.java
+++ b/src/main/java/ssu/opensource/service/task/TaskService.java
@@ -12,6 +12,7 @@ import ssu.opensource.dto.task.request.TargetDateDto;
 import ssu.opensource.dto.task.request.TaskCreateDto;
 import ssu.opensource.dto.task.request.TaskStatusDto;
 import ssu.opensource.dto.task.request.TaskUpdateDto;
+import ssu.opensource.dto.task.response.TaskDashboardDto;
 import ssu.opensource.dto.task.response.TaskDetailDto;
 import ssu.opensource.dto.task.response.TasksDto;
 import ssu.opensource.dto.task.response.TodoTaskDto;
@@ -30,6 +31,7 @@ import ssu.opensource.service.user.UserRetriever;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -293,5 +295,44 @@ public class TaskService {
         User user = userRetriever.findByUserId(userId);
         Task task = taskRetriever.findByUserAndId(user, taskId);
         taskUpdater.editDetails(task, taskUpdateDto);
+    }
+
+    public TaskDashboardDto getDashboard(
+            final Long userId,
+            final LocalDate startDate,
+            final LocalDate endDate,
+            final Boolean isMonth
+    ) {
+        User user = userRetriever.findByUserId(userId);
+        if (isMonth != null) { // 지난 1달
+            LocalDate now = LocalDate.now();
+            LocalDate past = isMonth ? now.minusDays(29) : now.minusDays(6);
+            return calcDashBoard(user, past, now);
+
+        } else if (startDate != null && endDate != null) {
+            return calcDashBoard(user, startDate, endDate);
+
+        } else {
+            throw new IllegalArgumentException(IllegalArgumentErrorCode.INVALID_ARGUMENTS);
+        }
+    }
+
+    // 대시보드
+    private TaskDashboardDto calcDashBoard(final User user, final LocalDate past, final LocalDate now){
+        int completeTasks = taskStatusRetriever.countAllTasksInPeriod(user, past, now, Status.DONE);
+        int avgInprogressTasks = taskStatusRetriever.countAllTasksInPeriod(user, past, now, Status.IN_PROGRESS);
+        int avgDeferredTasks = taskStatusRetriever.countAllTasksInPeriod(user, past, now, Status.DEFERRED);
+        int assignedTasks = taskRetriever.countAllAssignedTasksInPeriod(user.getId(), past, now);
+
+        double avgInprogressDate = Math.round(((double) avgInprogressTasks / ChronoUnit.DAYS.between(past, now)) * 10) / 10.0;
+        double avgDeferredRate = 0;
+        if (assignedTasks != 0) { // 할당된 작업이 있는 경우에만 계산
+            avgDeferredRate = Math.round(((double) avgDeferredTasks / assignedTasks) * 1000) / 10.0;
+        }
+        return TaskDashboardDto.builder()
+                .completeTasks(completeTasks)
+                .avgInprogressTasks(avgInprogressDate)
+                .avgDeferredRate(avgDeferredRate)
+                .build();
     }
 }


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #27 

&nbsp;

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->

### 완료한 할 일 갯수 , 평균 진행 중인 할 일 갯수
- 완료한 할 일 갯수 : (특정 기간 내) 완료 상태 가진 할 일 갯수
- 평균 진행 중인 할 일 갯수 : 진행중 상태 가진 할 일 갯수 / 설정한 기간 term

&nbsp;

💡새롭게 알게 된 점
쿼리문으로 바로 갯수를 count 할 수 있구나!


---
&nbsp;

### 평균 지연율 
- (특정 기간 내) 지연된 할 일 갯수 / assigned 된 일 갯수
assigned_date는 Task에 있으므로 TaskRepository에서 쿼리문을 작성하여 찾았습니다.

&nbsp;

### 실행 결과

<img width="785" alt="image" src="https://github.com/user-attachments/assets/c795e044-727a-485a-a48c-457289c63eb4">
<img width="781" alt="image" src="https://github.com/user-attachments/assets/84b9f59c-845c-4aed-a422-b76f293d3739">
<img width="784" alt="image" src="https://github.com/user-attachments/assets/48669f68-b88e-4849-b300-85377625e9f4">

평균 진행중인 일과 평균 지연율은 소숫점 둘째 자리에서 반올림 했습니다!
isMonth는 기획의 명세대로 오늘포함 30일 이전 날짜까지 즉, 오늘이 7월 12일이면 6/13-7/12일 까지의 날짜가 한 달이 됩니다. 

&nbsp;
